### PR TITLE
添加空字符逻辑

### DIFF
--- a/SCIndexView/SCIndexView.m
+++ b/SCIndexView/SCIndexView.m
@@ -310,6 +310,9 @@ static inline NSInteger SCPositionOfTextLayerInY(CGFloat y, CGFloat margin, CGFl
     }
     self.indicator.text = textLayer.string;
     
+    //空字符用于占位
+    if ([textLayer.string length] == 0) return;
+    
     if (animated) {
         self.indicator.alpha = 0;
         self.indicator.hidden = NO;
@@ -346,6 +349,10 @@ static inline NSInteger SCPositionOfTextLayerInY(CGFloat y, CGFloat margin, CGFl
     if (self.currentSection < 0 || self.currentSection >= (NSInteger)self.subTextLayers.count) return;
     
     CATextLayer *textLayer = self.subTextLayers[self.currentSection];
+    
+    //空字符用于占位
+    if ([textLayer.string length] == 0) return;
+    
     UIColor *backgroundColor, *foregroundColor;
     if (selected) {
         backgroundColor = self.configuration.indexItemSelectedBackgroundColor;

--- a/SCIndexView/SCIndexView.m
+++ b/SCIndexView/SCIndexView.m
@@ -228,7 +228,10 @@ static inline NSInteger SCPositionOfTextLayerInY(CGFloat y, CGFloat margin, CGFl
         [self.tableView setContentOffset:CGPointMake(0, -insetHeight) animated:NO];
     } else {
         NSIndexPath *indexPath = [NSIndexPath indexPathForRow:0 inSection:self.currentSection + self.startSection];
-        [self.tableView scrollToRowAtIndexPath:indexPath atScrollPosition:UITableViewScrollPositionTop animated:NO];
+        //处理段落无数据
+        if ([self.tableView cellForRowAtIndexPath:indexPath] != nil) {
+            [self.tableView scrollToRowAtIndexPath:indexPath atScrollPosition:UITableViewScrollPositionTop animated:NO];
+        }
     }
     
     if (self.isTouchingIndexView) {


### PR DESCRIPTION
如果标题数组和段落数量不匹配时，需要添加空字符串来占位，只需要事件不需要高亮和指示。
场景：上下有譬如：最近联系人、黑名单的段落，不需要索引字母。